### PR TITLE
Store dates as utcnow instead of server now as it seems timezone info…

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -6,6 +6,7 @@ import datetime
 
 from dateutil.parser import parse as parse_date
 
+import ckan.lib.helpers as h
 import ckan.lib.navl.dictization_functions
 import ckan.logic as logic
 import ckan.plugins as p
@@ -334,14 +335,12 @@ def xloader_status(context, data_dict):
         db.init(config)
         job_detail = db.get_job(job_id)
 
-        # timestamp is a date, so not sure why this code was there
-        # for log in job_detail['logs']:
-        #     if 'timestamp' in log:
-        #         date = time.strptime(
-        #             log['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
-        #         date = datetime.datetime.utcfromtimestamp(
-        #             time.mktime(date))
-        #         log['timestamp'] = date
+        # Attach time zone data to logs if needed
+        for log in job_detail['logs']:
+            if 'timestamp' in log:
+                date = log['timestamp']
+                if not date.tzinfo:
+                    log['timestamp'] = h.get_display_timezone().localize(date)
     try:
         error = json.loads(task['error'])
     except ValueError:

--- a/ckanext/xloader/db.py
+++ b/ckanext/xloader/db.py
@@ -197,7 +197,7 @@ def add_pending_job(job_id, job_type, api_key,
             job_id=job_id,
             job_type=job_type,
             status='pending',
-            requested_timestamp=datetime.datetime.now(),
+            requested_timestamp=datetime.datetime.utcnow(),
             sent_data=data,
             result_url=result_url,
             api_key=api_key))
@@ -324,7 +324,7 @@ def mark_job_as_completed(job_id, data=None):
     update_dict = {
         "status": "complete",
         "data": json.dumps(data),
-        "finished_timestamp": datetime.datetime.now(),
+        "finished_timestamp": datetime.datetime.utcnow(),
     }
     _update_job(job_id, update_dict)
 
@@ -339,7 +339,7 @@ def mark_job_as_missed(job_id):
     update_dict = {
         "status": "error",
         "error": "Job delayed too long, service full",
-        "finished_timestamp": datetime.datetime.now(),
+        "finished_timestamp": datetime.datetime.utcnow(),
     }
     _update_job(job_id, update_dict)
 
@@ -358,7 +358,7 @@ def mark_job_as_errored(job_id, error_object):
     update_dict = {
         "status": "error",
         "error": error_object,
-        "finished_timestamp": datetime.datetime.now(),
+        "finished_timestamp": datetime.datetime.utcnow(),
     }
     _update_job(job_id, update_dict)
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -547,7 +547,7 @@ class StoringHandler(logging.Handler):
 
             conn.execute(db.LOGS_TABLE.insert().values(
                 job_id=self.task_id,
-                timestamp=datetime.datetime.now(),
+                timestamp=datetime.datetime.utcnow(),
                 message=message,
                 level=level,
                 module=module,


### PR DESCRIPTION
… is dropped and stored. i.e. +10 means that we get dates in the future which shows up as -1 days when the job ran