### PR TITLE
QOL-7596 ckan 2.9

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@
 exclude =
     ckan
     scripts
+    .git
 
 # Extended output format.
 format = pylint

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -77,9 +77,9 @@ def xloader_data_into_datastore(input):
         job_dict['status'] = 'complete'
         db.mark_job_as_completed(job_id, job_dict)
     except JobError as e:
-        db.mark_job_as_errored(job_id, str(e))
+        db.mark_job_as_errored(job_id, six.text_type(e))
         job_dict['status'] = 'error'
-        job_dict['error'] = str(e)
+        job_dict['error'] = six.text_type(e)
         log = logging.getLogger(__name__)
         log.error('xloader error: {0}, {1}'.format(e, traceback.format_exc()))
         errored = True
@@ -87,7 +87,7 @@ def xloader_data_into_datastore(input):
         db.mark_job_as_errored(
             job_id, traceback.format_tb(sys.exc_info()[2])[-1] + repr(e))
         job_dict['status'] = 'error'
-        job_dict['error'] = str(e)
+        job_dict['error'] = six.text_type(e)
         log = logging.getLogger(__name__)
         log.error('xloader error: {0}, {1}'.format(e, traceback.format_exc()))
         errored = True
@@ -317,9 +317,9 @@ def _download_resource_data(resource, data, api_key, logger):
                        DOWNLOAD_TIMEOUT))
     except requests.exceptions.RequestException as e:
         try:
-            err_message = str(e.reason)
+            err_message = six.text_type(e.reason)
         except AttributeError:
-            err_message = str(e)
+            err_message = six.text_type(e)
         logger.warning('URL error: %s', err_message)
         raise HTTPError(
             message=err_message, status_code=None,

--- a/ckanext/xloader/schema.py
+++ b/ckanext/xloader/schema.py
@@ -1,3 +1,7 @@
+# encoding: utf-8
+
+import six
+
 import ckan.plugins as p
 import ckanext.datastore.logic.schema as dsschema
 
@@ -16,7 +20,7 @@ OneOf = get_validator('OneOf')
 if p.toolkit.check_ckan_version('2.9'):
     unicode_safe = get_validator('unicode_safe')
 else:
-    unicode_safe = str
+    unicode_safe = six.text_type
 
 
 def xloader_submit_schema():

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import sqlalchemy.orm as orm
 import datetime
+import six
 from decimal import Decimal
 
 from ckan.tests import factories
@@ -779,10 +780,10 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=PrintLogger(),
             )
-        assert "Error with field definition" in str(exception.value)
+        assert "Error with field definition" in six.text_type(exception.value)
         assert (
             '"<?xml version="1.0" encoding="utf-8" ?>" is not a valid field name'
-            in str(exception.value)
+            in six.text_type(exception.value)
         )
 
     def test_geojson(self):
@@ -796,10 +797,10 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=PrintLogger(),
             )
-        assert "Error with field definition" in str(exception.value)
+        assert "Error with field definition" in six.text_type(exception.value)
         assert (
             '"{"type":"FeatureCollection"" is not a valid field name'
-            in str(exception.value)
+            in six.text_type(exception.value)
         )
 
     def test_shapefile_zip(self):

--- a/ckanext/xloader/tests/test_plugin.py
+++ b/ckanext/xloader/tests/test_plugin.py
@@ -1,6 +1,9 @@
+# encoding: utf-8
+
 import datetime
 import pytest
 import mock
+import six
 from ckan.tests import helpers, factories
 from ckan.logic import _actions
 
@@ -57,7 +60,7 @@ class TestNotify(object):
             "entity_id": resource_id,
             "entity_type": "resource",
             "task_type": "xloader",
-            "last_updated": str(datetime.datetime.utcnow()),
+            "last_updated": six.text_type(datetime.datetime.utcnow()),
             "state": "pending",
             "key": "xloader",
             "value": "{}",


### PR DESCRIPTION
- Merge upstream commits into history
- Expand usage of 'six' for string compatibility