### PR TITLE
QOL-9327 fix syntax for new query string parameter

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -269,7 +269,7 @@ def _download_resource_data(resource, data, api_key, logger):
             # changed, or something went wrong and we want a clean start.
             # Either way, we don't want a cached file.
             download_url = url_parts._replace(
-                query=url_parts.query + '&nonce=' + time.time()
+                query='{}&nonce={}'.format(url_parts.query, time.time())
             ).geturl()
         else:
             download_url = url

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -155,6 +155,8 @@ class xloaderPlugin(plugins.SingletonPlugin):
             if toolkit.get_action('datastore_info')(
                     context=context, data_dict={'id': resource_dict['id']}):
                 datastore_exists = True
+            else:
+                datastore_exists = False
         except toolkit.ObjectNotFound:
             datastore_exists = False
 


### PR DESCRIPTION
Concatenating a string and a timestamp requires `format`, not just `+`.