### PR TITLE
Conditional DataStore Tab in Resource Edit

### DIFF
--- a/ckanext/xloader/helpers.py
+++ b/ckanext/xloader/helpers.py
@@ -25,3 +25,9 @@ def xloader_status_description(status):
         return captions.get(status['status'], status['status'].capitalize())
     else:
         return _('Not Uploaded Yet')
+
+
+def is_xloader_format(resource_format):
+    from ckanext.xloader.plugin import XLoaderFormats
+
+    return XLoaderFormats.is_it_an_xloader_format(resource_format)

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -211,4 +211,5 @@ class xloaderPlugin(plugins.SingletonPlugin):
         return {
             "xloader_status": xloader_helpers.xloader_status,
             "xloader_status_description": xloader_helpers.xloader_status_description,
+            "is_xloader_format": xloader_helpers.is_xloader_format,
         }

--- a/ckanext/xloader/templates/package/resource_edit_base.html
+++ b/ckanext/xloader/templates/package/resource_edit_base.html
@@ -2,5 +2,7 @@
 
 {% block inner_primary_nav %}
     {{ super() }}
-    {{ h.build_nav_icon('xloader.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+    {% if h.is_xloader_format(res.format) or res.datastore_active %}
+      {{ h.build_nav_icon('xloader.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+    {% endif %}
 {% endblock %}

--- a/ckanext/xloader/templates/package/resource_edit_base.html
+++ b/ckanext/xloader/templates/package/resource_edit_base.html
@@ -2,7 +2,10 @@
 
 {% block inner_primary_nav %}
     {{ super() }}
-    {% if h.is_xloader_format(res.format) or res.datastore_active %}
-      {{ h.build_nav_icon('xloader.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+    {%
+      if (h.is_xloader_format(res.format) or res.datastore_active)
+      and res.url_type not in h.datastore_rw_resource_url_types()
+    %}
+      {{ h.build_nav_icon('xloader.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id, icon='cloud-upload') }}
     {% endif %}
 {% endblock %}

--- a/ckanext/xloader/templates/package/resource_read.html
+++ b/ckanext/xloader/templates/package/resource_read.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block action_manage %}
+  {{ super() }}
+  {%
+    if (h.is_xloader_format(res.format) or res.datastore_active)
+    and h.check_access('package_update', {'id':pkg.id })
+    and res.url_type not in h.datastore_rw_resource_url_types()
+  %}
+    <li>{% link_for _('DataStore'), named_route='xloader.resource_data', id=pkg.name, resource_id=res.id, class_='btn btn-light', icon='cloud-upload' %}</li>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
feat(templates): conditional DataStore tab;

Added helper for valid xloader formats.
Added condition to display the DataStore tab in Resource Edit.

See https://github.com/ckan/ckanext-xloader/pull/190 for more details/discussion.