### PR TITLE
[QOLDEV-490] use fast loading for resources that already have a data dictionary

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -153,6 +153,10 @@ def xloader_submit(context, data_dict):
         }
     }
     timeout = config.get('ckanext.xloader.job_timeout', '3600')
+    if not utils.datastore_resource_exists(res_id):
+        # Expand timeout for resources that have to be type-guessed
+        timeout = timeout * 3
+
     try:
         job = enqueue_job(
             jobs.xloader_data_into_datastore, [data], rq_kwargs=dict(timeout=timeout)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -212,7 +212,7 @@ def xloader_data_into_datastore_(input, job_dict):
     logger.info("'use_type_guessing' mode is: %s",
                 use_type_guessing)
     try:
-        if use_type_guessing:
+        if use_type_guessing and not loader.datastore_resource_exists(resource['id']):
             tabulator_load()
         else:
             try:

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -18,10 +18,9 @@ import sqlalchemy as sa
 from ckan import model
 from ckan.plugins.toolkit import get_action, asbool, ObjectNotFound, config
 
-from . import loader
-from . import db
+from . import db, loader
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
-from .utils import set_resource_metadata
+from .utils import set_resource_metadata, should_guess_types
 
 try:
     from ckan.lib.api_token import get_user_from_token
@@ -206,13 +205,10 @@ def xloader_data_into_datastore_(input, job_dict):
     logger.info('Loading CSV')
     # If ckanext.xloader.use_type_guessing is not configured, fall back to
     # deprecated ckanext.xloader.just_load_with_messytables
-    use_type_guessing = asbool(config.get(
-        'ckanext.xloader.use_type_guessing', config.get(
-            'ckanext.xloader.just_load_with_messytables', False)))
-    logger.info("'use_type_guessing' mode is: %s",
-                use_type_guessing)
+    use_type_guessing = should_guess_types(resource['id'])
+    logger.info("'use_type_guessing' mode is: %s", use_type_guessing)
     try:
-        if use_type_guessing and not loader.datastore_resource_exists(resource['id']):
+        if use_type_guessing:
             tabulator_load()
         else:
             try:

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -17,7 +17,7 @@ import ckan.plugins as p
 
 from .job_exceptions import FileCouldNotBeLoadedError, LoaderError
 from .parser import CSV_SAMPLE_LINES, XloaderCSVParser
-from .utils import headers_guess, type_guess
+from .utils import datastore_resource_exists, headers_guess, type_guess
 
 from ckan.plugins.toolkit import config
 
@@ -400,17 +400,6 @@ def send_resource_to_datastore(resource_id, headers, records):
     except p.toolkit.ValidationError as e:
         raise LoaderError('Validation error writing rows to db: {}'
                           .format(str(e)))
-
-
-def datastore_resource_exists(resource_id):
-    from ckan import model
-    context = {'model': model, 'ignore_auth': True}
-    try:
-        response = p.toolkit.get_action('datastore_search')(context, dict(
-            id=resource_id, limit=0))
-    except p.toolkit.ObjectNotFound:
-        return False
-    return response or {'fields': []}
 
 
 def delete_datastore_resource(resource_id):


### PR DESCRIPTION
- Tabulator is good at type guessing but is slow. Once it has configured the column types, there's no need to use it every time.