### PR TITLE
[QOLDEV-490] always use COPY for large files

### DIFF
--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -29,9 +29,7 @@ groups:
         default: 1_000_000_000
         example: 100000
         description: |
-            The connection string for the jobs database used by XLoader. The
-            default of an sqlite file is fine for development. For production use a
-            Postgresql database.
+            The maximum file size that XLoader will attempt to load.
         type: int
         required: false
       - key: ckanext.xloader.use_type_guessing
@@ -48,6 +46,15 @@ groups:
         type: bool
         required: false
         legacy_key: ckanext.xloader.just_load_with_messytables
+      - key: ckanext.xloader.max_type_guessing_length
+        default: 0
+        example: 100000
+        description: |
+            The maximum file size that will be passed to Tabulator if the
+            use_type_guessing flag is enabled. Larger files will use COPY even if
+            the flag is set. Defaults to 1/10 of the maximum content length.
+        type: int
+        required: false
       - key: ckanext.xloader.parse_dates_dayfirst
         default: False
         example: False

--- a/ckanext/xloader/templates/package/resource_read.html
+++ b/ckanext/xloader/templates/package/resource_read.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block action_manage_inner %}
+{% block action_manage %}
   {{ super() }}
   {% if h.is_resource_supported_by_xloader(res) %}
     <li>{% link_for _('DataStore'), named_route='xloader.resource_data', id=pkg.name, resource_id=res.id, class_='btn btn-light', icon='cloud-upload' %}</li>

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from decimal import Decimal
 
 import ckan.plugins as p
-from ckan.plugins.toolkit import asbool, config
+from ckan.plugins.toolkit import config
 
 # resource.formats accepted by ckanext-xloader. Must be lowercase here.
 DEFAULT_FORMATS = [
@@ -255,10 +255,3 @@ def datastore_resource_exists(resource_id):
     except p.toolkit.ObjectNotFound:
         return False
     return response or {'fields': []}
-
-
-def should_guess_types(resource_id):
-    return asbool(
-        config.get('ckanext.xloader.use_type_guessing', config.get(
-            'ckanext.xloader.just_load_with_messytables', False))) \
-        and datastore_resource_exists(resource_id)


### PR DESCRIPTION
- Ignore the 'use_type_guessing' flag for large files since they will take too long.