### PR TITLE
fix datastore delete button layout from #68

### DIFF
--- a/ckanext/xloader/templates/xloader/resource_data.html
+++ b/ckanext/xloader/templates/xloader/resource_data.html
@@ -10,7 +10,7 @@
 
   {% block delete_ds_button %}
     {% if res.datastore_active %}
-      <form method="post" action="{{ delete_action }}" class="mb-3 d-inline-block">
+      <form method="post" action="{{ delete_action }}" class="mb-3 d-inline-block pull-right">
         {{ h.csrf_input() if 'csrf_input' in h }}
         <a href="{{ h.url_for('xloader.delete_datastore_table', id=pkg.id, resource_id=res.id) }}"
           class="btn btn-danger pull-left"
@@ -18,7 +18,7 @@
           data-module="confirm-action"
           data-module-with-data=true
           data-module-content="{{ _('Are you sure you want to delete the DataStore and Data Dictionary?') }}"
-          >{% block delete_datastore_button_text %}<i class="fa fa-remove"></i>{{ _('Delete from DataStore') }}{% endblock %}</a>
+          >{% block delete_datastore_button_text %}<i class="fa fa-remove"></i> {{ _('Delete from DataStore') }}{% endblock %}</a>
       </form>
     {% endif %}
   {% endblock %}


### PR DESCRIPTION
https://github.com/qld-gov-au/ckanext-xloader/pull/68 is a useful feature but the layout is wrong.

- Add a space between the label icon and text
- Float the button right so it coexists properly with the Upload button