### PR TITLE
Fix datastore deletion button

### DIFF
--- a/ckanext/xloader/templates/xloader/resource_data.html
+++ b/ckanext/xloader/templates/xloader/resource_data.html
@@ -4,15 +4,14 @@
 
 {% block primary_content_inner %}
 
-  {% set action = h.url_for('xloader.resource_data', id=pkg.name, resource_id=res.id) %}
-  {% set delete_action = h.url_for('xloader.delete_datastore_table', id=pkg.id, resource_id=res.id) %}
   {% set show_table = true %}
 
   {% block delete_ds_button %}
     {% if res.datastore_active %}
+      {% set delete_action = h.url_for('xloader.delete_datastore_table', id=pkg.id, resource_id=res.id) %}
       <form method="post" action="{{ delete_action }}" class="mb-3 d-inline-block pull-right">
         {{ h.csrf_input() if 'csrf_input' in h }}
-        <a href="{{ h.url_for('xloader.delete_datastore_table', id=pkg.id, resource_id=res.id) }}"
+        <a href="{{ delete_action }}"
           class="btn btn-danger pull-left"
           type="submit"
           data-module="confirm-action"
@@ -24,7 +23,7 @@
   {% endblock %}
 
   {% block upload_ds_button %}
-    <form method="post" action="{{ action }}" class="datapusher-form mb-3 d-inline-block">
+    <form method="post" action="{{ h.url_for('xloader.resource_data', id=pkg.name, resource_id=res.id) }}" class="datapusher-form mb-3 d-inline-block">
       {{ h.csrf_input() if 'csrf_input' in h }}
       <button class="btn btn-primary" name="save" type="submit">
         <i class="fa fa-cloud-upload"></i> {{ _('Upload to DataStore') }}


### PR DESCRIPTION
- Move variable definitions inside the relevant blocks as they don't seem to be effective otherwise. This would have resulted in the delete button submitting to the current URL, which refreshes the data, instead of deleting, if the confirm-action JavaScript runs.