### PR TITLE
[QOLSVC-3902] reduce lock timeout to avoid deadlocks

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -116,11 +116,9 @@ def _clear_datastore_resource(resource_id):
     ''' Delete all records from the datastore table, without dropping the table itself.
     '''
     engine = get_write_engine()
-    connection = engine.connect()
-    try:
-        connection.execute('TRUNCATE TABLE "{}"'.format(resource_id))
-    finally:
-        connection.close()
+    with engine.begin() as conn:
+        conn.execute("SET LOCAL lock_timeout = '5s'")
+        conn.execute('TRUNCATE TABLE "{}"'.format(resource_id))
 
 
 def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):


### PR DESCRIPTION
- When clearing and reloading a resource, shorten the lock timeout so we fail fast instead of deadlocking