### PR TITLE
[QOLSVC-4959] try direct COPY if type guessing fails

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -245,7 +245,12 @@ def xloader_data_into_datastore_(input, job_dict, logger):
     logger.info("'use_type_guessing' mode is: %s", use_type_guessing)
     try:
         if use_type_guessing:
-            tabulator_load()
+            try:
+                tabulator_load()
+            except JobError as e:
+                logger.warning('Load using tabulator failed: %s', e)
+                logger.info('Trying again with direct COPY')
+                direct_load()
         else:
             try:
                 direct_load()


### PR DESCRIPTION
- Type guessing could fail eg if the first hundred rows are a consistent type but it changes later. Mirror the existing fallback behaviour by trying both styles, but in an order determined by the type guessing flag.