### PR TITLE
[QOLSVC-5123] handle empty cells past end of row

### DIFF
--- a/ckanext/xloader/helpers.py
+++ b/ckanext/xloader/helpers.py
@@ -31,8 +31,8 @@ def xloader_status_description(status):
 def is_resource_supported_by_xloader(res_dict, check_access=True):
     is_supported_format = XLoaderFormats.is_it_an_xloader_format(res_dict.get('format'))
     is_datastore_active = res_dict.get('datastore_active', False)
-    user_has_access = not check_access or toolkit.h.check_access('package_update',
-                                                                 {'id':res_dict.get('package_id')})
+    user_has_access = not check_access or toolkit.h.check_access(
+        'package_update', {'id': res_dict.get('package_id')})
     url_type = res_dict.get('url_type')
     if url_type:
         try:


### PR DESCRIPTION
- Excel tends to generate files with lots of extra commas at the end of every row. The header row ignores them, so data rows need to be able to ignore them as well.
- Also strip trailing whitespace from headers after truncating them, in case the truncation exposed some, see https://github.com/ckan/ckanext-xloader/pull/210/