### PR TITLE
[QOLSVC-5551] restart all sequences when truncating table

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -119,7 +119,7 @@ def _clear_datastore_resource(resource_id):
     engine = get_write_engine()
     with engine.begin() as conn:
         conn.execute("SET LOCAL lock_timeout = '5s'")
-        conn.execute('TRUNCATE TABLE "{}"'.format(resource_id))
+        conn.execute('TRUNCATE TABLE "{}" RESTART IDENTITY'.format(resource_id))
 
 
 def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):


### PR DESCRIPTION
Some publishers are relying on generated IDs to be stable.