### PR TITLE
[QOLSVC-3902] make deadlock handling slightly more forgiving

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -124,6 +124,7 @@ def xloader_data_into_datastore(input):
             if tries < MAX_RETRIES:
                 tries = tries + 1
                 log.info("Job %s failed due to temporary error [%s], retrying", job_id, e)
+                logger.info("Job failed due to temporary error [%s], retrying", e)
                 job_dict['status'] = 'pending'
                 job_dict['metadata']['tries'] = tries
                 enqueue_job(

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -118,7 +118,7 @@ def _clear_datastore_resource(resource_id):
     '''
     engine = get_write_engine()
     with engine.begin() as conn:
-        conn.execute("SET LOCAL lock_timeout = '5s'")
+        conn.execute("SET LOCAL lock_timeout = '15s'")
         conn.execute('TRUNCATE TABLE "{}" RESTART IDENTITY'.format(resource_id))
 
 


### PR DESCRIPTION
- Extend timeout from 5 seconds, which might be tripped by mere slowness, to 15 seconds
- Add an externally visible log message when lock times out