### PR TITLE
fix: asset inclusion must be in the block being rendered,

### DIFF
--- a/ckanext/xloader/templates/package/resource_read.html
+++ b/ckanext/xloader/templates/package/resource_read.html
@@ -5,6 +5,7 @@
   {% set badge = h.xloader_badge(res) %}
   {% if badge %}
     {{ badge }}<br/><br/>
+    {% asset 'ckanext-xloader/main-css' %}
   {% endif %}
   {{ super() }}
 {% endblock %}
@@ -23,4 +24,4 @@
   {{ super() }}
 {% endblock %}
 
-{% asset 'ckanext-xloader/main-css' %}
+

--- a/ckanext/xloader/templates/package/snippets/resource_info.html
+++ b/ckanext/xloader/templates/package/snippets/resource_info.html
@@ -3,6 +3,5 @@
 {% block resource_info %}
   {{ super() }}
   {{ h.xloader_badge(res) }}
+  {% asset 'ckanext-xloader/main-css' %}
 {% endblock %}
-
-{% asset 'ckanext-xloader/main-css' %}

--- a/ckanext/xloader/templates/package/snippets/resource_item.html
+++ b/ckanext/xloader/templates/package/snippets/resource_item.html
@@ -17,6 +17,7 @@
 {% block resource_item_title %}
   {{ super() }}
   {{ h.xloader_badge(res) }}
+  {% asset 'ckanext-xloader/main-css' %}
 {% endblock %}
 
-{% asset 'ckanext-xloader/main-css' %}
+

--- a/ckanext/xloader/webassets/css/xloader.css
+++ b/ckanext/xloader/webassets/css/xloader.css
@@ -8,7 +8,10 @@
   vertical-align: middle;
   font-weight: 400;
   line-height: 1.2;
-  text-decoration: none;
+}
+
+a.loader-badge {
+ text-decoration: none;
 }
 
 .loader-badge:hover,


### PR DESCRIPTION
 not on the outer that is not rendered