### PR TITLE
QOLSVC-4633 improve hash method and add more tests

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -111,7 +111,13 @@ def get_default_queue_name(package_id=None):
         return DEFAULT_QUEUE_NAME
     if not package_id:
         return DEFAULT_QUEUE_NAMES[0]
-    return DEFAULT_QUEUE_NAMES[ord(package_id[0]) % len(DEFAULT_QUEUE_NAMES)]
+
+    # Pick a queue by taking the first character of the package name
+    # and converting it into a numeric index to the list of queue names.
+    # We don't want a proper hash function, because those tend to add
+    # complications for the sake of (unnecessary) cryptographic strength.
+    queue_index = ord(package_id[0]) % len(DEFAULT_QUEUE_NAMES)
+    return DEFAULT_QUEUE_NAMES[queue_index]
 
 
 def xloader_data_into_datastore(input):

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -111,7 +111,7 @@ def get_default_queue_name(package_id=None):
         return DEFAULT_QUEUE_NAME
     if not package_id:
         return DEFAULT_QUEUE_NAMES[0]
-    return DEFAULT_QUEUE_NAMES[hash(package_id) % len(DEFAULT_QUEUE_NAMES)]
+    return DEFAULT_QUEUE_NAMES[ord(package_id[0]) % len(DEFAULT_QUEUE_NAMES)]
 
 
 def xloader_data_into_datastore(input):
@@ -383,7 +383,7 @@ def _download_resource_data(resource, data, api_key, logger):
     logger.info('Fetching from: {0}'.format(url))
     tmp_file = get_tmp_file(url)
     length = 0
-    m = hashlib.md5()
+    m = hashlib.md5(usedforsecurity=False)
     cl = None
     try:
         headers = {}

--- a/ckanext/xloader/tests/test_action.py
+++ b/ckanext/xloader/tests/test_action.py
@@ -32,7 +32,7 @@ class TestAction(object):
                 resource_id=res["id"],
             )
             assert 1 == enqueue_mock.call_count
-            assert enqueue_mock.call_args[1].get('queue') == 'default{}'.format(hash(res['package_id']) % 2)
+            assert enqueue_mock.call_args[1].get('queue') == 'default{}'.format(ord(res['package_id'][0]) % 2)
 
     def test_submit_nonexistent_resource(self):
         user = factories.User()

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -91,10 +91,6 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
         assert jobs.get_default_queue_name("foo") == "default0"
         assert jobs.get_default_queue_name("meh") == "default1"
 
-    @pytest.mark.ckan_config("ckanext.xloader.queue_names", "")
-    def test_default_queue_name_when_not_supplied(self):
-        assert jobs.get_default_queue_name("foo") == "default"
-
     def test_xloader_data_into_datastore(self, cli, data):
         self.enqueue(jobs.xloader_data_into_datastore, [data])
         with mock.patch("ckanext.xloader.jobs.get_response", get_response):

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -88,10 +88,8 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
 
     def test_derive_queue_name(self):
         assert jobs.get_default_queue_name() == "default0"
-        # hash('foo') == -2531596919889323877
-        assert jobs.get_default_queue_name("foo") == "default1"
-        # hash('meh') == 7803861252145539596
-        assert jobs.get_default_queue_name("meh") == "default0"
+        assert jobs.get_default_queue_name("foo") == "default0"
+        assert jobs.get_default_queue_name("meh") == "default1"
 
     @pytest.mark.ckan_config("ckanext.xloader.queue_names", "")
     def test_default_queue_name_when_not_supplied(self):

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -86,6 +86,17 @@ def data(create_with_upload, apikey):
 @pytest.mark.ckan_config("ckan.jobs.timeout", 2)
 class TestXLoaderJobs(helpers.FunctionalRQTestBase):
 
+    def test_derive_queue_name(self):
+        assert jobs.get_default_queue_name() == "default0"
+        # hash('foo') == -2531596919889323877
+        assert jobs.get_default_queue_name("foo") == "default1"
+        # hash('meh') == 7803861252145539596
+        assert jobs.get_default_queue_name("meh") == "default0"
+
+    @pytest.mark.ckan_config("ckanext.xloader.queue_names", "")
+    def test_default_queue_name_when_not_supplied(self):
+        assert jobs.get_default_queue_name("foo") == "default"
+
     def test_xloader_data_into_datastore(self, cli, data):
         self.enqueue(jobs.xloader_data_into_datastore, [data])
         with mock.patch("ckanext.xloader.jobs.get_response", get_response):


### PR DESCRIPTION
Built-in `hash` is inconsistent across Python executions, for cryptographic reasons, which is the opposite of what we want. Replaced with a very simple check of the first character in the package ID.