### PR TITLE
Develop to master - load config at plugin configure time

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -158,9 +158,9 @@ def xloader_submit(context, data_dict):
             'queue_name': custom_queue,
         }
     }
-    if custom_queue not in jobs.DEFAULT_QUEUE_NAMES:
+    if custom_queue not in jobs.default_queue_names:
         # Don't automatically retry if it's a custom run
-        data['metadata']['tries'] = jobs.MAX_RETRIES
+        data['metadata']['tries'] = jobs.max_retries
 
     # Expand timeout for resources that have to be type-guessed
     timeout = config.get(

--- a/ckanext/xloader/auth.py
+++ b/ckanext/xloader/auth.py
@@ -1,6 +1,6 @@
 from ckan import authz
 
-from .jobs import DEFAULT_QUEUE_NAMES
+from .jobs import default_queue_names
 
 import ckanext.datastore.logic.auth as auth
 
@@ -8,7 +8,7 @@ import ckanext.datastore.logic.auth as auth
 def xloader_submit(context, data_dict):
     # only sysadmins can specify a custom processing queue
     custom_queue = data_dict.get('queue')
-    if custom_queue and custom_queue not in DEFAULT_QUEUE_NAMES:
+    if custom_queue and custom_queue not in default_queue_names:
         return authz.is_authorized('config_option_update', context, data_dict)
     return auth.datastore_auth(context, data_dict)
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -30,19 +30,9 @@ from ckan.lib.api_token import get_user_from_token
 
 log = logging.getLogger(__name__)
 
-SSL_VERIFY = asbool(config.get('ckanext.xloader.ssl_verify', True))
-if not SSL_VERIFY:
-    requests.packages.urllib3.disable_warnings()
-
-DEFAULT_QUEUE_NAMES = config.get('ckanext.xloader.queue_names', DEFAULT_QUEUE_NAME).split()
-MAX_CONTENT_LENGTH = int(config.get('ckanext.xloader.max_content_length') or 1e9)
-# Don't try Tabulator load on large files
-MAX_TYPE_GUESSING_LENGTH = int(config.get('ckanext.xloader.max_type_guessing_length') or MAX_CONTENT_LENGTH / 10)
-MAX_EXCERPT_LINES = int(config.get('ckanext.xloader.max_excerpt_lines') or 0)
 CHUNK_SIZE = 16 * 1024  # 16kb
 DOWNLOAD_TIMEOUT = 30
 
-MAX_RETRIES = int(config.get('ckanext.xloader.max_retries', 1))
 RETRYABLE_ERRORS = (
     errors.DeadlockDetected,
     errors.LockNotAvailable,
@@ -50,10 +40,16 @@ RETRYABLE_ERRORS = (
     HTTPError,
     XLoaderTimeoutError
 )
-# Retries can only occur in cases where the datastore entry exists,
-# so use the standard timeout
-RETRIED_JOB_TIMEOUT = config.get('ckanext.xloader.job_timeout', '3600')
-APITOKEN_HEADER_NAME = config.get('apitoken_header_name', 'Authorization')
+
+# Variables that are set from config values and must be available to all jobs
+ssl_verify = None
+max_content_length = None
+max_type_guessing_length = None
+max_excerpt_lines = None
+max_retries = None
+retried_job_timeout = None
+apitoken_header_name = None
+default_queue_names = DEFAULT_QUEUE_NAME.split()
 
 
 def is_retryable_error(error):
@@ -107,17 +103,17 @@ def get_default_queue_name(package_id=None):
 
     By sending all jobs for a dataset to the same queue, lock conflicts are reduced.
     """
-    if not DEFAULT_QUEUE_NAMES:
+    if not default_queue_names:
         return DEFAULT_QUEUE_NAME
     if not package_id:
-        return DEFAULT_QUEUE_NAMES[0]
+        return default_queue_names[0]
 
     # Pick a queue by taking the first character of the package name
     # and converting it into a numeric index to the list of queue names.
     # We don't want a proper hash function, because those tend to add
     # complications for the sake of (unnecessary) cryptographic strength.
-    queue_index = ord(package_id[0]) % len(DEFAULT_QUEUE_NAMES)
-    return DEFAULT_QUEUE_NAMES[queue_index]
+    queue_index = ord(package_id[0]) % len(default_queue_names)
+    return default_queue_names[queue_index]
 
 
 def xloader_data_into_datastore(input):
@@ -206,7 +202,7 @@ def handle_retryable_error(e, input, job_id, job_dict, logger, error_state):
     """
     if isinstance(e, RETRYABLE_ERRORS) and is_retryable_error(e):
         tries = job_dict['metadata'].get('tries', 0)
-        if tries < MAX_RETRIES:
+        if tries < max_retries:
             tries = tries + 1
             log.info("Job %s failed due to temporary error [%s], retrying", job_id, e)
             logger.info("Job failed due to temporary error [%s], retrying", e)
@@ -217,7 +213,7 @@ def handle_retryable_error(e, input, job_id, job_dict, logger, error_state):
                 [input],
                 title="retry xloader_data_into_datastore: resource: {} attempt {}".format(
                     job_dict['metadata']['resource_id'], tries),
-                rq_kwargs=dict(timeout=RETRIED_JOB_TIMEOUT)
+                rq_kwargs=dict(timeout=retried_job_timeout)
             )
             return True
     db.mark_job_as_errored(
@@ -327,7 +323,7 @@ def xloader_data_into_datastore_(input, job_dict, logger):
             config.get('ckanext.xloader.use_type_guessing', config.get(
                 'ckanext.xloader.just_load_with_messytables', False))) \
             and not datastore_resource_exists(resource['id']) \
-            and os.path.getsize(tmp_file.name) <= MAX_TYPE_GUESSING_LENGTH
+            and os.path.getsize(tmp_file.name) <= max_type_guessing_length
         logger.info("'use_type_guessing' mode is: %s", use_type_guessing)
         try:
             if use_type_guessing:
@@ -345,8 +341,8 @@ def xloader_data_into_datastore_(input, job_dict, logger):
                     logger.info('Trying again with tabulator')
                     tabulator_load()
         except JobTimeoutException:
-            logger.warning('Job timed out after %ss', RETRIED_JOB_TIMEOUT)
-            raise JobError('Job timed out after {}s'.format(RETRIED_JOB_TIMEOUT))
+            logger.warning('Job timed out after %ss', retried_job_timeout)
+            raise JobError('Job timed out after {}s'.format(retried_job_timeout))
         except FileCouldNotBeLoadedError as e:
             logger.warning('Loading excerpt for this format not supported.')
             logger.error('Loading file raised an error: %s', e)
@@ -365,8 +361,8 @@ def _download_resource_data(resource, data, api_key, logger):
     :param api_key: CKAN api key - needed to obtain resources that are private
     :param logger:
 
-    If the download is bigger than MAX_CONTENT_LENGTH then it just downloads a
-    excerpt (of MAX_EXCERPT_LINES) for preview, and flags it by setting
+    If the download is bigger than max_content_length then it just downloads a
+    excerpt (of max_excerpt_lines) for preview, and flags it by setting
     data['datastore_contains_all_records_of_source_file'] = False
     which will be saved to the resource later on.
     '''
@@ -391,7 +387,7 @@ def _download_resource_data(resource, data, api_key, logger):
         if resource.get('url_type') == 'upload':
             # If this is an uploaded file to CKAN, authenticate the request,
             # otherwise we won't get file from private resources
-            headers[APITOKEN_HEADER_NAME] = api_key
+            headers[apitoken_header_name] = api_key
 
             # Add a constantly changing parameter to bypass URL caching.
             # If we're running XLoader, then either the resource has
@@ -406,14 +402,14 @@ def _download_resource_data(resource, data, api_key, logger):
         response = get_response(download_url, headers)
 
         cl = response.headers.get('content-length')
-        if cl and int(cl) > MAX_CONTENT_LENGTH:
+        if cl and int(cl) > max_content_length:
             response.close()
             raise DataTooBigError()
 
         # download the file to a tempfile on disk
         for chunk in response.iter_content(CHUNK_SIZE):
             length += len(chunk)
-            if length > MAX_CONTENT_LENGTH:
+            if length > max_content_length:
                 raise DataTooBigError
             tmp_file.write(chunk)
             m.update(chunk)
@@ -424,13 +420,13 @@ def _download_resource_data(resource, data, api_key, logger):
         cleanup_temp_file(tmp_file)
         message = 'Data too large to load into Datastore: ' \
             '{cl} bytes > max {max_cl} bytes.' \
-            .format(cl=cl or length, max_cl=MAX_CONTENT_LENGTH)
+            .format(cl=cl or length, max_cl=max_content_length)
         logger.warning(message)
-        if MAX_EXCERPT_LINES <= 0:
+        if max_excerpt_lines <= 0:
             raise JobError(message)
         logger.info('Loading excerpt of ~{max_lines} lines to '
                     'DataStore.'
-                    .format(max_lines=MAX_EXCERPT_LINES))
+                    .format(max_lines=max_excerpt_lines))
         tmp_file = get_tmp_file(url)
         response = get_response(url, headers)
         length = 0
@@ -441,7 +437,7 @@ def _download_resource_data(resource, data, api_key, logger):
             m.update(line)
             length += len(line)
             line_count += 1
-            if length > MAX_CONTENT_LENGTH or line_count >= MAX_EXCERPT_LINES:
+            if length > max_content_length or line_count >= max_excerpt_lines:
                 break
         response.close()
         data['datastore_contains_all_records_of_source_file'] = False
@@ -469,8 +465,8 @@ def _download_resource_data(resource, data, api_key, logger):
             request_url=url, response=None)
     except JobTimeoutException:
         cleanup_temp_file(tmp_file)
-        logger.warning('Job timed out after %ss', RETRIED_JOB_TIMEOUT)
-        raise JobError('Job timed out after {}s'.format(RETRIED_JOB_TIMEOUT))
+        logger.warning('Job timed out after %ss', retried_job_timeout)
+        raise JobError('Job timed out after {}s'.format(retried_job_timeout))
 
     logger.info('Downloaded ok - %s', printable_file_size(length))
     file_hash = m.hexdigest()
@@ -481,7 +477,7 @@ def _download_resource_data(resource, data, api_key, logger):
 def get_response(url, headers):
     def get_url():
         kwargs = {'headers': headers, 'timeout': DOWNLOAD_TIMEOUT,
-                  'verify': SSL_VERIFY, 'stream': True}  # just gets the headers for now
+                  'verify': ssl_verify, 'stream': True}  # just gets the headers for now
         if 'ckan.download_proxy' in config:
             proxy = config.get('ckan.download_proxy')
             kwargs['proxies'] = {'http': proxy, 'https': proxy}
@@ -537,14 +533,14 @@ def callback_xloader_hook(result_url, api_key, job_dict):
         if ':' in api_key:
             header, key = api_key.split(':')
         else:
-            header, key = APITOKEN_HEADER_NAME, api_key
+            header, key = apitoken_header_name, api_key
         headers[header] = key
 
     try:
         result = requests.post(
             modify_input_url(result_url),  # modify with local config
             data=json.dumps(job_dict, cls=DatetimeJsonEncoder),
-            verify=SSL_VERIFY,
+            verify=ssl_verify,
             headers=headers)
     except requests.ConnectionError:
         return False

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -2,14 +2,16 @@
 
 import logging
 
+import requests
 from ckan import plugins
 from ckan.plugins import toolkit
 
 from ckan.model.domain_object import DomainObjectOperation
 from ckan.model.resource import Resource
 
-from . import action, auth, helpers as xloader_helpers, utils
+from . import action, auth, helpers as xloader_helpers, jobs, utils
 from ckanext.xloader.utils import XLoaderFormats
+from ckan.lib.jobs import DEFAULT_QUEUE_NAME
 
 try:
     from ckanext.validation.interfaces import IPipeValidation
@@ -69,6 +71,25 @@ class xloaderPlugin(plugins.SingletonPlugin):
             self.ignore_hash = True
         else:
             self.ignore_hash = False
+
+        # Set config values that need to be available to all jobs, without loading
+        # the config itself in every single job
+        jobs.ssl_verify = toolkit.asbool(config_.get('ckanext.xloader.ssl_verify', True))
+        if not jobs.ssl_verify:
+            requests.packages.urllib3.disable_warnings()
+
+        jobs.max_content_length = int(config_.get('ckanext.xloader.max_content_length') or 1e9)
+        # Don't try Tabulator load on large files
+        jobs.max_type_guessing_length = int(
+            config_.get('ckanext.xloader.max_type_guessing_length') or jobs.max_content_length / 10
+        )
+        jobs.max_excerpt_lines = int(config_.get('ckanext.xloader.max_excerpt_lines') or 0)
+        jobs.max_retries = int(config_.get('ckanext.xloader.max_retries', 1))
+        # Retries can only occur in cases where the datastore entry exists,
+        # so use the standard timeout
+        jobs.retried_job_timeout = config_.get('ckanext.xloader.job_timeout', '3600')
+        jobs.apitoken_header_name = config_.get('apitoken_header_name', 'Authorization')
+        jobs.default_queue_names = config_.get('ckanext.xloader.queue_names', DEFAULT_QUEUE_NAME).split()
 
     # IPipeValidation
 

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -188,12 +188,12 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
             stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
             assert "Data too large to load into Datastore:" in stdout
 
+    @pytest.mark.ckan_config("ckanext.xloader.max_excerpt_lines", 1)
     def test_data_max_excerpt_lines_config(self, cli, data):
         self.enqueue(jobs.xloader_data_into_datastore, [data])
         with mock.patch("ckanext.xloader.jobs.get_response", get_large_response):
-            with mock.patch("ckanext.xloader.jobs.MAX_EXCERPT_LINES", 1):
-                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
-                assert "Loading excerpt of ~1 lines to DataStore." in stdout
+            stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+            assert "Loading excerpt of ~1 lines to DataStore." in stdout
 
         resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
         assert resource["datastore_contains_all_records_of_source_file"] is False


### PR DESCRIPTION
Delay loading config so that plugins like `ckanext-envvars` have time to work.